### PR TITLE
Fix deployment steps and add usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,23 @@ Error responses follow the format:
    Generate a secure token, then:
    ```sh
    wrangler secret put API_PROBE_TOKEN
+   ```
+
+3. **Test Locally:**
+   Run the worker in development mode:
+   ```sh
+   wrangler dev
+   ```
+
+4. **Deploy:**
+   Publish the worker to Cloudflare:
+   ```sh
+   wrangler publish
+   ```
+
+## Usage
+
+After deployment, access the endpoints via your worker URL. For example:
+```sh
+curl https://<your-worker>.workers.dev/ping
+```


### PR DESCRIPTION
## Summary
- finish Deployment section in README and close code block
- add instructions for `wrangler dev` and `wrangler publish`
- document basic usage example

## Testing
- `npm test` *(fails: Jest couldn't parse ECMAScript module syntax)*
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_6852a82b61bc832dbed3afe0b4283b3a