### PR TITLE
Fix duplicate header in security middleware

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,8 +27,6 @@ function addSecurityHeaders(headers) {
   headers.set("Expires", "0");
   // Additional security headers
   headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
-  // Prevent content type sniffing
-  headers.set("X-Content-Type-Options", "nosniff");
   
   return headers;
 }


### PR DESCRIPTION
## Summary
- remove redundant `X-Content-Type-Options` header in `addSecurityHeaders`

## Testing
- `npm test` *(fails: SyntaxError in jest runner)*

------
https://chatgpt.com/codex/tasks/task_e_6852a834eb5c832db4b050997ab9b739